### PR TITLE
Do not download apt key if already present

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Debian | Add keys authenticity
-  apt_key: url={{ url_apt_key }}0x7F0CEB10
+  apt_key: url={{ url_apt_key }}0x{{ id_apt_key }} id={{ id_apt_key }}
 
 - name: Debian | Add source sources
   apt_repository: repo='{{ mongodb_repository }}' update_cache=yes

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,5 @@
 ---
 
 url_apt_key: "http://keyserver.ubuntu.com/pks/lookup?op=get&search="
+id_apt_key: 7F0CEB10
 mongodb_repository: "deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen"


### PR DESCRIPTION
If the apt key is already present, there is no need to download it again.

That's useful in environments where you don't have full internet access and you pre-provision the key for example.